### PR TITLE
Enable https on chester.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,12 @@ ansible-playbook blog.yml -i vagrant_hosts,
 
 (alternatively you can use `-i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory`, but it will log in with the default user for Ubuntu provisioning, not the `{{ admin_user }}` defined on the global vars)
 
-To test, run this script (to redirect ports and add entries to `/etc/hosts`):
-
+Run this script to enable development sites (it redirects ports - until reboot - and add entries to `/etc/hosts`; run it again to revert all changes):
 ```
-sudo ./redirect_sites
+sudo ./config-dev-environment
 ```
 
-Now you when you open, say, [http://chester.me](http://chester.me), you will get the Vagrant version, not the public one. Don't forget to run it again (which reverts all changes) as you shutdown your VM!
+Now you can open, say, [http://dev.chester.me](http://dev.chester.me).
 
 ### Passwords vault
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 443, host: 8443
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "provisioning.yml"

--- a/blog.yml
+++ b/blog.yml
@@ -13,22 +13,22 @@
 
   roles:
     - role: chesterbr.vault
-    - role: chesterbr.nginx
-      nginx_sites:
-        - server:
-            file_name: chester.me
-            root: "{{ blog_public_dir }}"
-            server_name: chester.me
-        - server:
-            file_name: redirects.chester.me
-            server_name: www.chester.me m.chester.me chester.blog.br www.chester.blog.br
-            return: 301 $scheme://chester.me$request_uri
-
     - role: chesterbr.letsencrypt
       webroot: "{{ blog_public_dir }}"
       domains:
         - chester.me
         - www.chester.me
+    - role: chesterbr.nginx
+      nginx_sites:
+        - server:
+            file_name: chester.me
+            root: "{{ blog_public_dir }}"
+            server_name: chester.me dev.chester.me
+            https_server_name: chester.me
+        - server:
+            file_name: redirects.chester.me
+            server_name: www.chester.me m.chester.me chester.blog.br www.chester.blog.br
+            return: 301 $scheme://chester.me$request_uri
     - role: chesterbr.ruby
       ruby_user: "{{ admin_user }}"
 

--- a/blog.yml
+++ b/blog.yml
@@ -24,6 +24,11 @@
             server_name: www.chester.me m.chester.me chester.blog.br www.chester.blog.br
             return: 301 $scheme://chester.me$request_uri
 
+    - role: chesterbr.letsencrypt
+      webroot: "{{ blog_public_dir }}"
+      domains:
+        - chester.me
+        - www.chester.me
     - role: chesterbr.ruby
       ruby_user: "{{ admin_user }}"
 

--- a/config_dev_environment
+++ b/config_dev_environment
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# This script sets up a development environment by:
+#   - Forwarding local ports 80/433 to 8080/8043
+#     (which Vagrantfile will, on its turn, forward to the VM's 80/433)
+#   - Adding development site names to /etc/hosts
+#
+# That way, we can test, say, the blog by opening http://dev.chester.me
+#
+# Run it again to remove the entries and restore port forwarding to boot-time config
+#
+
+if [ "$(id -u)" != "0" ]; then
+  echo "This script must be run as root" 1>&2
+  exit 1
+fi
+
+# TODO: somehow get those from nginx configurations (this list does not include
+# redirects); also review non-dev-m. prefixed sites (and possibly split redirects)
+DEVELOPMENT_SITES="dev.chester.me
+                   dev.cruzalinhas.com
+                   dev.totransit.chester.me"
+
+TAB=$'\t'
+
+add_dev_site() {
+  SITE_NAME=$1
+  echo "$SITE_NAME"
+  echo "127.0.0.1${TAB}${SITE_NAME}" >> /etc/hosts
+}
+
+remove_dev_site() {
+  SITE_NAME=$1
+  sed -i.bak "/^127\.0\.0\.1${TAB}${SITE_NAME}$/d" /etc/hosts
+}
+
+
+STATUS=`pfctl -s nat -q | grep rdr.*8080 | wc -l`
+
+if [ $STATUS != '0' ]; then
+  pfctl -F all -f /etc/pf.conf
+  echo
+  echo "=== Port forwarding stopped"
+  while read -r SITE; do
+    remove_dev_site $SITE
+  done <<< "$DEVELOPMENT_SITES"
+  echo "=== Development sites removed from /etc/hosts"
+else
+  echo "
+    rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
+    rdr pass inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+  " | pfctl -ef -
+  echo
+  echo "=== Port forwarding started. Forwarding these:"
+  pfctl -s nat -q
+  echo
+  echo "=== Adding development sites to /etc/hosts:"
+  while read -r SITE; do
+    add_dev_site $SITE
+  done <<< "$DEVELOPMENT_SITES"
+fi

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -3,6 +3,7 @@
 # support files if we deem so)
 admin_user: chester
 admin_user_key: https://github.com/chesterbr.keys
+admin_email: cd@pobox.com
 
 # Ansible needs to use Python 2.7
 ansible_python_interpreter: /usr/bin/python2.7

--- a/roles/chesterbr.letsencrypt/tasks/main.yml
+++ b/roles/chesterbr.letsencrypt/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Install the letsencrypt package
+  become: yes
+  apt: name=letsencrypt state=present
+
+- name: Obtain certificates for selected sites (only if running on production server)
+  become: yes
+  shell: bash -lc "letsencrypt certonly -m {{ admin_email }} --keep-until-expiring --agree-tos --webroot -w {{ webroot }} -d {{ domains | join(' -d ') }}"
+  when: "'production' in group_names"
+
+- name: Ensure ssl directory exists (development-only; prod will use letsencypt)
+  become: yes
+  file: path=/etc/nginx/ssl state=directory
+  when: "'vagrant' in group_names"
+
+- name: Generate self-signed certificate (development-only; prod will use letsencypt)
+  become: yes
+  command: openssl req -new -nodes -x509 -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN=${ansible_fqdn}" -days 3650 -keyout /etc/nginx/ssl/privkey.pem -out /etc/nginx/ssl/fullchain.pem -extensions v3_ca creates=/etc/nginx/ssl/fullchain.pem
+  when: "'vagrant' in group_names"

--- a/roles/chesterbr.nginx/templates/site.j2
+++ b/roles/chesterbr.nginx/templates/site.j2
@@ -4,7 +4,7 @@ server {
 	error_log /var/log/nginx/{{ item.server.file_name }}-error.log;
 
 {% for k,v in item.server.iteritems() %}
-{% if k.find('location') == -1 and k != 'file_name' %}
+{% if k.find('location') == -1 and k != 'file_name' and k != 'https_server_name' %}
 {{ k }} {{ v }};
 {% endif %}
 {% endfor %}
@@ -17,4 +17,45 @@ server {
   }
 {% endfor %}
 }
+
+{% if 'https_server_name' in item.server %}
+  {% if 'vagrant' in group_names %}
+    {% set ssl_certificate_dir = "/etc/nginx/ssl" %}
+  {% elif 'production' in group_names %}
+    {% set ssl_certificate_dir = "/etc/letsencrypt/live/" ~ item.server.https_server_name %}
+  {% endif %}
+
+  server {
+    listen 443;
+    server_name {{ item.server.https_server_name }};
+    root {{ item.server.root }};
+
+    ssl on;
+    ssl_certificate {{ ssl_certificate_dir }}/fullchain.pem;
+    ssl_certificate_key {{ ssl_certificate_dir }}/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    add_header Strict-Transport-Security max-age=15768000;
+
+    # OCSP Stapling ---
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    error_page 500 502 503 504 /500.html;
+    client_max_body_size 4G;
+    keepalive_timeout 10;
+
+    if ($request_method !~ ^(GET|HEAD|PUT|PATCH|POST|DELETE|OPTIONS)$ ){
+      return 405;
+    }
+  }
+
+{% endif %}
 

--- a/roles/chesterbr.security/tasks/main.yml
+++ b/roles/chesterbr.security/tasks/main.yml
@@ -37,11 +37,18 @@
     - 50unattended-upgrades
 
 - name: Configure ufw (firewall) rules
+  become: yes
   ufw: rule=allow port={{ item }}
   with_items:
     - 22
     - 80
+    - 443
     - 6912
+  tags:
+    - firewall
 
 - name: Enable ufw and load it on startup; reject any connections not on rules
+  become: yes
   ufw: state=enabled policy=reject
+  tags:
+    - firewall


### PR DESCRIPTION
- Create a "dev environment" script that tweaks `/etc/hosts` and network (so we can use the standard ports on Vagrant)
- On dev, self-generates a certificate
- On prod uses letsencrypt / certbot

TODO:
- Update blog to remove `http:` prefixes
- Auto-update certificate (cron?)
- Evaluate configuration at some site
- Consider forcing https