### PR TITLE
fix: attempts to drop the new administration acc

### DIFF
--- a/rpi.yml
+++ b/rpi.yml
@@ -92,7 +92,7 @@
 
   # Uncomment if you don't want the local pi user
   # - name: Drop the pi user (we don't need it and can't even use it remotely at this point)
-  #   user: name={{ admin_user }} state=absent remove=yes
+  #   user: name=pi state=absent remove=yes
 
   - name: Install unattended upgrades package and dependencies.
     apt: name={{ packages }} state=present


### PR DESCRIPTION
Thanks heaps for sharing this project, it's a great starting point and hence I have stolen a couple of pointers for my own home raspberry pi project.

I noticed that the line commented attempts to remove the new admin account and not the default account.

 * dropping the admin user and not the default account when uncommented.