### PR TITLE
Uses sudo instead of su in rails restart scripts so pumas get the SIGTERM

### DIFF
--- a/cruzalinhas.yml
+++ b/cruzalinhas.yml
@@ -89,6 +89,8 @@
       template: src=templates/cruzalinhas.conf.supervisor.j2 dest=/etc/supervisor/conf.d/cruzalinhas.conf
       become: yes
       notify: reload supervisor
+      tags:
+        - configure_supervisor
 
     - name: Download and update SPTrans data
       command: bash -lc "cd {{ cruzalinhas_checkout_dir }}; DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake sptrans:import"

--- a/templates/cruzalinhas.conf.supervisor.j2
+++ b/templates/cruzalinhas.conf.supervisor.j2
@@ -1,2 +1,2 @@
 [program:cruzalinhas]
-command=su {{ server_user }} -lc "cd {{ cruzalinhas_checkout_dir }}; bin/rails server"
+command=sudo -u {{ server_user }} bash -lc "cd {{ cruzalinhas_checkout_dir }}; bin/rails server"

--- a/templates/totransit.conf.supervisor.j2
+++ b/templates/totransit.conf.supervisor.j2
@@ -1,2 +1,2 @@
 [program:totransit]
-command=su {{ server_user }} -lc 'cd {{ totransit_app_dir }}; bundle exec rails server -p 3001'
+command=sudo -u {{ server_user }} bash -lc "cd {{ totransit_app_dir }}; bin/rails server -p 3001"

--- a/totransit.yml
+++ b/totransit.yml
@@ -79,6 +79,8 @@
       template: src=templates/totransit.conf.supervisor.j2 dest=/etc/supervisor/conf.d/totransit.conf
       become: yes
       notify: reload supervisor
+      tags:
+        - configure_supervisor
 
     - name: Initialize database
       command: bash -lc "cd {{ totransit_app_dir }}; bundle exec rake db:create"


### PR DESCRIPTION
Closes #15 by ensuring the stop signal is properly propagated.

With this, `supervisorctl restart cruzalinhas` (or `totransit`) work as expected.